### PR TITLE
Set productEntityId as undefined in CartCustomItem type

### DIFF
--- a/lib/bigcommerce/types.ts
+++ b/lib/bigcommerce/types.ts
@@ -491,6 +491,7 @@ export type DigitalOrPhysicalItem = {
 
 export type CartCustomItem = {
   entityId: string;
+  productEntityId: undefined;
   sku: string;
   name: string;
   quantity: number;
@@ -500,6 +501,7 @@ export type CartCustomItem = {
 
 type CartGiftCertificate = {
   entityId: number;
+  productEntityId: undefined;
   name: string;
   amount: BigCommerceMoney;
   isTaxable: boolean;


### PR DESCRIPTION
This resolves the following issue on build:
<img width="864" alt="Screenshot 2023-06-01 at 4 51 41 PM" src="https://github.com/vercel/commerce/assets/2677921/da372f5a-d043-4666-8ee6-523b8f71aa25">

The reason it failed is because productEntityId doesn't exist on the CartCustomItem type and Typescript can't access properties it doesn't know about, so it errors out on the deconstruction of productEntityId even though the other type in the union has it.

By adding the property as undefined on the CartCustomItem type, this issue is resolved without changing the cart mapper logic and respecting the rest of the typings.