### PR TITLE
Add Customer Impersonation Token to ENV

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,4 +26,8 @@ BIGCOMMERCE_CHANNEL_ID=""
 # * Storefront API Customer Impersonation Tokens
 # * Carts modify
 # For more information, see  https://developer.bigcommerce.com/api-docs/getting-started/api-accounts#oauth-scopes
-BIGCOMMERCE_ACCESS_TOKEN="" 
+BIGCOMMERCE_ACCESS_TOKEN=""
+# Use BigCommerce Docs to create this Token
+# For more information, see https://developer.bigcommerce.com/docs/storefront-auth/tokens/customer-impersonation-token
+# Storefront API token that allows your application to impersonate customers when making GraphQL
+BIGCOMMERCE_CUSTOMER_IMPERSONATION_TOKEN="" 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Next.js + BigCommerce requires a [BigCommerce sandbox](https://developer.bigcomm
 
 - [Next.js + BigCommerce Configuration](https://developer.bigcommerce.com/api-docs/storefronts/nextjs-commerce)
 - [Guide to Building Headless Storefronts](https://developer.bigcommerce.com/api-docs/storefronts/guide/overview)
+- [How to generate Customer Impersonation Token](https://developer.bigcommerce.com/docs/storefront-auth/tokens/customer-impersonation-token)
 
 ## Develop locally
 

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,8 +1,10 @@
+import { MetadataRoute } from 'next';
+
 const baseUrl = process.env.NEXT_PUBLIC_VERCEL_URL
   ? `https://${process.env.NEXT_PUBLIC_VERCEL_URL}`
   : 'http://localhost:3000';
 
-export default function robots() {
+export default function robots(): MetadataRoute.Robots {
   return {
     rules: [
       {
@@ -11,5 +13,5 @@ export default function robots() {
     ],
     sitemap: `${baseUrl}/sitemap.xml`,
     host: baseUrl
-  };
+  }
 }

--- a/lib/bigcommerce/index.ts
+++ b/lib/bigcommerce/index.ts
@@ -30,7 +30,7 @@ import {
   searchProductsQuery
 } from './queries/product';
 import { getEntityIdByRouteQuery } from './queries/route';
-import { fetchStorefrontToken, memoizedCartRedirectUrl } from './storefront-config';
+import { memoizedCartRedirectUrl } from './storefront-config';
 import {
   BigCommerceAddToCartOperation,
   BigCommerceCart,
@@ -94,15 +94,11 @@ export async function bigCommerceFetch<T>({
   cache?: RequestCache;
 }): Promise<{ status: number; body: T } | never> {
   try {
-    const {
-      data: { token }
-    } = await fetchStorefrontToken();
-
     const result = await fetch(endpoint, {
       method: 'POST',
       headers: {
         Accept: 'application/json',
-        Authorization: `Bearer ${token}`,
+        Authorization: `Bearer ${process.env.BIGCOMMERCE_CUSTOMER_IMPERSONATION_TOKEN}`,
         'Content-Type': 'application/json',
         ...headers
       },
@@ -111,7 +107,6 @@ export async function bigCommerceFetch<T>({
         ...(variables && { variables })
       }),
       cache,
-      next: { revalidate: 900 } // 15 minutes
     });
 
     const body = await result.json();

--- a/lib/bigcommerce/mappers.ts
+++ b/lib/bigcommerce/mappers.ts
@@ -323,7 +323,7 @@ export const bigCommerceToVercelPageContent = (page: BigCommercePage): VercelPag
   return {
     id: page.entityId.toString(),
     title: page.name,
-    handle: page.path,
+    handle: page.path.slice(1),
     body: page.htmlBody ?? '',
     bodySummary: page.plainTextSummary ?? '',
     seo: {

--- a/lib/bigcommerce/storefront-config.ts
+++ b/lib/bigcommerce/storefront-config.ts
@@ -1,12 +1,5 @@
 import { BIGCOMMERCE_API_URL } from './constants';
 
-interface StorefrontTokenResponse {
-  data: {
-    token: string;
-  };
-  meta: unknown;
-}
-
 interface StorefrontCheckoutResponse {
   data?: {
     cart_url: string;
@@ -50,24 +43,3 @@ const createCartRedirectUrl = () => {
 }
 
 export const memoizedCartRedirectUrl = createCartRedirectUrl();
-
-export const fetchStorefrontToken = async () => {
-  const response = await fetch(
-    `${BIGCOMMERCE_API_URL}/stores/${process.env.BIGCOMMERCE_STORE_HASH}/v3/storefront/api-token-customer-impersonation`,
-    {
-      method: 'POST',
-      headers: {
-        accept: 'application/json',
-        'content-type': 'application/json',
-        'x-auth-token': process.env.BIGCOMMERCE_ACCESS_TOKEN!,
-        'x-bc-customer-id': ''
-      },
-      body: JSON.stringify({
-        channel_id: parseInt(process.env.BIGCOMMERCE_CHANNEL_ID!),
-        expires_at: Math.floor(new Date().getTime() / 1000) + 1 * 24 * 60 * 60 // 1 day
-      })
-    }
-  );
-
-  return (await response.json()) as StorefrontTokenResponse;
-};


### PR DESCRIPTION
### What/Why

Previously, we've auto generated a Customer Impersonation Token (CIT) on each GraphQL request within 
`bigCommerceFetch` method.  Now we change the logic and move this step on the side of User. That means from now on  User should generate CIT by himself/herself and put it on `.env` file and regenerate once it is going to expire. README is updated with link to our docs how to generate  CIT via endpoint.  

Additionally, `revalidate` option has been removed  from fetching so only `cache: force-cache` option is stayed in place. This removes next warning:

 `Warning: fetch for https://store-xxx.mybigcommerce.com/graphql on ... specified "cache: force-cache" and "revalidate: 900", only one should be specified.`



