### PR TITLE
fix error when product image unavailable

### DIFF
--- a/lib/bigcommerce/mappers.ts
+++ b/lib/bigcommerce/mappers.ts
@@ -73,8 +73,8 @@ const bigCommerceToVercelVariants = (
 const bigCommerceToVercelProduct = (product: BigCommerceProduct): VercelProduct => {
   const createVercelProductImage = (img: { url: string; altText: string }) => {
     return {
-      url: img.url,
-      altText: img.altText,
+      url: img ? img.url : '',
+      altText: img ? img.altText : '',
       width: 2048,
       height: 2048
     };
@@ -288,11 +288,8 @@ const bigCommerceToVercelCollection = (collection: BigCommerceCollection): Verce
 };
 
 export {
-  bigCommerceToVercelCart,
-  bigCommerceToVercelProduct,
-  bigCommerceToVercelProducts,
-  bigCommerceToVercelCollection,
-  vercelFromBigCommerceLineItems
+  bigCommerceToVercelCart, bigCommerceToVercelCollection, bigCommerceToVercelProduct,
+  bigCommerceToVercelProducts, vercelFromBigCommerceLineItems
 };
 
 export const vercelToBigCommerceSorting = (


### PR DESCRIPTION
### What / Why

Here is a small update on a case when product's image is not available.

### Proof

Locally tested
Before:
![Screenshot 2023-07-03 at 11 15 06](https://github.com/bigcommerce/nextjs-commerce/assets/67792608/d922cfee-e843-4e63-8899-dede7bc1d23b)
After:
![Screenshot 2023-07-03 at 11 14 05](https://github.com/bigcommerce/nextjs-commerce/assets/67792608/4b36d87b-e749-4b14-aaf1-aadf9ae18567)

